### PR TITLE
Add skeletonization approach to video preprocessing

### DIFF
--- a/video_preprocessing.py
+++ b/video_preprocessing.py
@@ -4,11 +4,13 @@ import pandas as pd
 import json
 import os
 import cv2 as cv
+from skimage import morphology
 from matplotlib import pyplot as plt
 import random
 
 data_dir = './data/' #define data directory
 video_dir = './data/videos/' #define videos directory
+skeletonized_video_dir = './data/skeletonized_videos/' #define skeletonized videos directory
 wlas_df = pd.read_json(data_dir + 'WLASL_v0.3.json') #returns df with cols ['gloss', 'instances'] - i.e. all json instances for a gloss, e.g. 'book'
 
 # function to return list of included video ids according to what's been downloaded
@@ -81,6 +83,64 @@ def save_frame_jpg(video_id):
     else:
         print("ERROR: save_frame_jpg() - failed to retrieve frame from video with ID {}".format(video_id))
 
+# Function to skeletonize the sign language videos
+def skeletonize_video(video_id):
+    vid_file_path = f'{video_dir}/{video_id}.mp4'
+
+    cap = cv.VideoCapture(vid_file_path)
+
+    # Initialize the kernel for morphological operations
+    kernel = cv.getStructuringElement(cv.MORPH_CROSS, (3,3))
+
+    # Create an empty list to store the binary images
+    binary_image_list = []
+
+    # Extract binary images for each frame of the video
+    while True:
+        res, frame = cap.read()
+        if res:
+            # Convert the frame to grayscale
+            gray = cv.cvtColor(frame, cv.COLOR_BGR2GRAY)
+
+            # Apply Otsu's thresholding method to obtain a binary image
+            ret, binary_image = cv.threshold(gray, 0, 255, cv.THRESH_BINARY + cv.THRESH_OTSU)
+
+            # Append the binary image to the list
+            binary_image_list.append(binary_image)
+        else:
+            break
+
+    cap.release()
+
+    # Create an empty list to store the skeletonized images
+    skeletonized_image_list = []
+
+    # Perform skeletonization on each binary image
+    for binary_image in binary_image_list:
+        # Apply morphological opening operation
+        opening = cv.morphologyEx(binary_image, cv.MORPH_OPEN, kernel)
+
+        # Threshold the opening image to ensure it only contains 0s and 1s
+        opening[opening > 0] = 1
+
+        # Perform skeletonization using skimage's skeletonize function
+        skeleton = morphology.skeletonize(opening.astype(np.uint8))
+
+        # Append the skeletonized image to the list
+        skeletonized_image_list.append(skeleton)
+
+    # Save the skeletonized images as video
+    out_file_path = f'{skeletonized_video_dir}/{video_id}_skeletonized.mp4'
+
+    height, width = skeletonized_image_list[0].shape[:2]
+    fourcc = cv.VideoWriter_fourcc(*'mp4v')
+    out = cv.VideoWriter(out_file_path, fourcc, 30.0, (width, height))
+
+    for skeletonized_image in skeletonized_image_list:
+        out.write((skeletonized_image * 255).astype(np.uint8))
+
+    out.release()
+
 def main():
 
     gloss_inst_df = get_json_as_df()
@@ -88,5 +148,5 @@ def main():
     # demonstrating use of save_frame_jpg function
     eg_vid_id = gloss_inst_df.iloc[0]['video_id']
     save_frame_jpg(eg_vid_id)
-
+    skeletonize_video(eg_vid_id)
 main()


### PR DESCRIPTION
The function skeletonize_video takes a video file and creates a new video file containing the skeletonized version of each frame in the original video. It does this by first converting each frame to binary using Otsu's thresholding method, performing morphological opening and skeletonization using skimage's skeletonize function, and then saving the resulting skeletonized frames as a new video file.