### PR TITLE
Generating train,test,val data from video keypoint arrays

### DIFF
--- a/mp_keypoint_extraction.py
+++ b/mp_keypoint_extraction.py
@@ -71,16 +71,31 @@ def extract_vid_keypoints(video_id, holistic=True, display=False):
         cap.release()
         cv.destroyAllWindows()    
 
-    # Save keypoints_list for the current video_id
-    if holistic:
-        path_suffix = '_holistic'
-    else:
-        path_suffix = ''
+    return frames_keypoints_lst, results
 
-    keypoints_file_path = f"{keypoints_dir}/{video_id}{path_suffix}.npy"
-    np.save(keypoints_file_path, frames_keypoints_lst)
+# iterates through available videos for each kind of split and saves as npy array
+def save_vids_keypoints(gloss_inst_df, holistic=True):
+    split_lst = gloss_inst_df['split'].unique().tolist()
+    num_vids = 3 #TODO - change later on - for testing purposes only
+    mp_dir = 'holistic' if holistic else 'pose'
 
-    return results
+    for split in split_lst:
+        split_df = gloss_inst_df[gloss_inst_df['split'] == split].sample(n=num_vids).reset_index()
+        split_file_path = f"{keypoints_dir}{mp_dir}/{split}/"
+        os.makedirs(split_file_path, exist_ok=True)
+
+        for i in range(num_vids):
+            vid_info = split_df.loc[i, ['video_id', 'split', 'gloss']]
+            vid_id = vid_info['video_id']
+            gloss = vid_info['gloss']
+
+            # print(vid_id, vid_split, gloss)
+
+            frames_keypoints_lst, _ = extract_vid_keypoints(vid_id)
+
+            # save keypoints for this video
+            vid_file_path = f"{split_file_path}{vid_id}_{gloss}.npy"
+            np.save(vid_file_path, np.array(frames_keypoints_lst))
 
 def draw_styled_landmarks(image, results):
     # Draw face connections

--- a/training.py
+++ b/training.py
@@ -1,0 +1,54 @@
+# from sklearn.model_selection import train_test_split
+import numpy as np
+import pandas as pd
+import os
+
+keypoints_dir = './data/keypoints/'  # define keypoints directory
+
+def generate_split_data(split, label_map, holistic=True):
+    y_labels = [] # ground truth labels
+    split_vids = [] # list of all (num_frames,num_keypoints) video npy arrays
+
+    # figuring out which keypoint directory to look in
+    if holistic:
+        mp_dir = 'holistic'
+    else:
+        mp_dir = 'pose'
+
+    split_dir = f"{keypoints_dir}{mp_dir}/{split}/"
+
+    # iterate through all available video npy arrays for this particular split
+    for npy_name in os.listdir(split_dir):
+        if npy_name != '.DS_Store':
+            f = os.path.join(split_dir, npy_name)
+            
+            # sample 50 consecutive frames from this array, since vids have diff lengths
+            vid_kp_npy = np.load(f)
+
+            vid_kp = pd.DataFrame(vid_kp_npy).sample(20).sort_index().reset_index(drop=True) 
+            print(f"gen_data for vid {npy_name}")
+
+            # extract gloss from the name of the .npy file
+            vid_gloss = npy_name.split('_')[1].split('.')[0]
+
+            print(split, npy_name, vid_gloss, vid_kp.shape)
+
+            split_vids.append(vid_kp)
+            y_labels.append(label_map[vid_gloss])
+
+    X = np.array(split_vids)
+    y = np.array(y_labels)
+
+    return X, y
+
+def main():
+    gloss_inst_df = pd.read_pickle("gloss_inst_df.pkl")
+
+    unique_glosses = gloss_inst_df['gloss'].unique().tolist()
+    gloss_label_map = {label:num for num, label in enumerate(unique_glosses)}
+
+    X_train, y_train = generate_split_data('train', gloss_label_map, holistic=True)
+    X_test, y_test = generate_split_data('test', gloss_label_map, holistic=True)
+    X_val, y_val = generate_split_data('val', gloss_label_map, holistic=True)
+    
+main()

--- a/video_preprocessing.py
+++ b/video_preprocessing.py
@@ -126,12 +126,10 @@ def skeletonize_video_frames(video_id):
 def main():
 
     gloss_inst_df = get_json_as_df()
+    gloss_inst_df.to_pickle("gloss_inst_df.pkl")
 
-    # demonstrating use of save_frame_jpg function
-    eg_vid_id = gloss_inst_df.iloc[0]['video_id']
-    #save_frame_jpg(eg_vid_id)
-    #skeletonize_video_frames(eg_vid_id)
-    # mp_keypoint_extraction.extract_keypoints(eg_vid_id)
-    mp_keypoint_extraction.extract_vid_keypoints(eg_vid_id)    
+    gloss_inst_df = pd.read_pickle("gloss_inst_df.pkl")
+
+    mp_keypoint_extraction.save_vids_keypoints(gloss_inst_df)
 
 main()


### PR DESCRIPTION
Added a 'save_vids_keypoints' function that takes the modified 'extract_vid_keypoints' function output and saves it for all videos for a number of samples specified across training, testing, validation data splits.

Also added a 'training.py' file which reads the keypoint numpy arrays saved for each split and loads it into a 3 dimensional numpy array suitable for future training with shape (num_video_samples, num_frames_in_video, num_keypoints)